### PR TITLE
No issue. Removed redundant '!' marks in resource names

### DIFF
--- a/de.tudarmstadt.ukp.uby.doc-asl/src/main/asciidoc/developer-guide/germanet.adoc
+++ b/de.tudarmstadt.ukp.uby.doc-asl/src/main/asciidoc/developer-guide/germanet.adoc
@@ -16,41 +16,41 @@
 
 == Implementation details of germanet-gpl module
 
-=== Conversion of !GermaNets Interlingual index to !SenseAxes
+=== Conversion of GermaNets Interlingual index to SenseAxes
 
-==== Informations of  an ILIRecord (each record mapped to !SenseAxis)
+==== Informations of  an ILIRecord (each record mapped to SenseAxis)
 
 |====
 | GermaNet identifier | Remark | Mapped to | Implemented?
 
 | lexUnitId 
-| id of !GermaNets lexical unit 
-| not directly mapped, but used for obtaining the corresponding UBY-LMF !LexicalEntry and determining values of !SenseAxis.synsetOne and !SenseAxis.senseOne 
+| id of GermaNets lexical unit 
+| not directly mapped, but used for obtaining the corresponding UBY-LMF LexicalEntry and determining values of SenseAxis.synsetOne and SenseAxis.senseOne 
 | Yes
 
 | ewnRelation 
-| the relation of the record to the corresponding !WordNets synset 
-| Not directly mapped, but used for determining which record should be converted to !SenseAxis instance(s). 
+| the relation of the record to the corresponding WordNets synset 
+| Not directly mapped, but used for determining which record should be converted to SenseAxis instance(s). 
 | Yes
 
 | pwnWord 
-| string representation of the word in !WordNets synset pointed by the record 
-| already mapped and implemented in WNConverter to !LexicalEntry.Lemma.!FormRepresentation.writtenForm 
+| string representation of the word in WordNets synset pointed by the record 
+| already mapped and implemented in WNConverter to LexicalEntry.Lemma.FormRepresentation.writtenForm 
 | -
 
 | pwn20Sense 
-| position of the word in !WordNets 2.0 synset pointed by the record 
-| already mapped and implemented in !WNConverter to Sense.index 
+| position of the word in WordNets 2.0 synset pointed by the record 
+| already mapped and implemented in WNConverter to Sense.index 
 | -
 
 | pwn20Id 
-| identifier of the !WordNets 2.0 synset that corresponds to this record (offset+POS) 
+| identifier of the WordNets 2.0 synset that corresponds to this record (offset+POS) 
 | not mapped 
 | -
 
 | pwn30Id 
-| identifier of the !WordNets 3.0 synset that corresponds to this record (offset+POS) 
-| not directly mapped, but used for obtaining the corresponding UBY-LMF synset and mapping its UBY-LMF ID to !SenseAxis.synsetTwo 
+| identifier of the WordNets 3.0 synset that corresponds to this record (offset+POS) 
+| not directly mapped, but used for obtaining the corresponding UBY-LMF synset and mapping its UBY-LMF ID to SenseAxis.synsetTwo 
 | Yes
 
 | pwn20paraphrase 
@@ -59,15 +59,15 @@
 | -
 
 | pwn20Synonyms 
-| words of !WordNets synset, that corresponds to this record 
-| !SenseAxis.senseTwo 
+| words of WordNets synset, that corresponds to this record 
+| SenseAxis.senseTwo 
 | Yes
 
 | source 
-| source of the record (!EuroWordNet or Tübingen University) 
+| source of the record (EuroWordNet or Tübingen University) 
 | not mapped 
 | -
 |====
 
 
-NOTE: Currently, only ILI Records with ewnRelation "synonym" are processed by the !GNConverter. Conversion of records with ewnRelation other than "synonym" will be implemented in a future UBY release.
+NOTE: Currently, only ILI Records with ewnRelation "synonym" are processed by the GNConverter. Conversion of records with ewnRelation other than "synonym" will be implemented in a future UBY release.


### PR DESCRIPTION
There were some '!' marks placed before some of the lexical resource names such as !OmegaWiki which used to be a wiki escape character and is not needed any more on github documentation page.